### PR TITLE
Protects against forgetting to close a file

### DIFF
--- a/spec/ssh2_spec.cr
+++ b/spec/ssh2_spec.cr
@@ -112,5 +112,6 @@ describe SSH2::SFTP do
         attrs.size.should eq(13)
       end
     end
+    GC.collect
   end
 end

--- a/src/sftp/node.cr
+++ b/src/sftp/node.cr
@@ -33,11 +33,5 @@ module SSH2::SFTP
     def closed?
       @closed || @sftp.closed?
     end
-
-    def finalize
-      return if closed?
-
-      close rescue nil
-    end
   end
 end

--- a/src/sftp/node.cr
+++ b/src/sftp/node.cr
@@ -33,5 +33,11 @@ module SSH2::SFTP
     def closed?
       @closed || @sftp.closed?
     end
+
+    def finalize
+      return if closed?
+
+      close rescue nil
+    end
   end
 end


### PR DESCRIPTION
When the GC runs and you forget to close a file an exception would be thrown. This protects you against that and allows the GC to close the file for you.  You shouldn't depend on this and should close the file manually, but this is a common theme throughout IO-ish objects in Crystal: https://github.com/crystal-lang/crystal/blob/60760a5460aa13a1f80c5a1a7410782dc4076b77/src/io/file_descriptor.cr#L135