### PR TITLE
Do not raise an error if a public key does not work for authentication

### DIFF
--- a/src/agent.cr
+++ b/src/agent.cr
@@ -39,8 +39,12 @@ class SSH2::Agent
     each_unsafe do |key|
       @session.perform_nonblock do
         ret = LibSSH2.agent_userauth(self, username, key)
+        case ret
+        when 0 then return true
+        when LibSSH2::ERROR_AUTHENTICATION_FAILED then 0
+        else ret
+        end
       end
-      return true if ret == 0
     end
     raise SSH2Error.new "Failed to authenticate username #{username} with SSH agent"
   end

--- a/src/lib_ssh2.cr
+++ b/src/lib_ssh2.cr
@@ -115,9 +115,10 @@ lib LibSSH2
     alias Stat = LibC::Stat
   {% end %}
 
-  ERROR_NONE          =   0
-  ERROR_SFTP_PROTOCOL = -31
-  ERROR_EAGAIN        = -37
+  ERROR_NONE                  =   0
+  ERROR_AUTHENTICATION_FAILED = -18
+  ERROR_SFTP_PROTOCOL         = -31
+  ERROR_EAGAIN                = -37
 
   fun session_init = libssh2_session_init_ex(alloc : Void*, free : Void*, realloc : Void*, user_data : Void*) : Session
   fun session_free = libssh2_session_free(session : Session) : Int32


### PR DESCRIPTION
@stakach I realized the change to agent authentication in #5 was not enough. Authentication failed completely if a single public key did not match.

With this PR, every key the agent supplies is correctly tried for authentication, while still failing if a different error happens.