### PR TITLE
fix for Crystal 0.35.0

### DIFF
--- a/src/channel.cr
+++ b/src/channel.cr
@@ -102,7 +102,7 @@ class SSH2::Channel < IO
     read(0, slice)
   end
 
-  def write(slice : Slice(UInt8)) : Nil
+  def write(slice : Slice(UInt8)) : Int64
     write(0, slice)
   end
 
@@ -228,7 +228,7 @@ class SSH2::Channel < IO
       @channel.read(@stream_id, slice)
     end
 
-    def write(slice : Slice(UInt8)) : Nil
+    def write(slice : Slice(UInt8)) : Int64
       @channel.write(@stream_id, slice)
     end
 

--- a/src/sftp/file.cr
+++ b/src/sftp/file.cr
@@ -26,7 +26,7 @@ module SSH2::SFTP
       @session.perform_nonblock { LibSSH2.sftp_read(self, slice, LibC::SizeT.new(slice.bytesize)) }
     end
 
-    def write(slice : Slice(UInt8)) : Nil
+    def write(slice : Slice(UInt8)) : Int64
       @session.perform_nonblock { LibSSH2.sftp_write(self, slice, LibC::SizeT.new(slice.bytesize)) }
     end
   end


### PR DESCRIPTION
> Another breaking-change in IO is that #skip, #write, #write_utf8, #write_byte, #write_bytes, and #skip_to_end return the number of bytes it skipped/written
https://crystal-lang.org/2020/06/09/crystal-0.35.0-released.html

Removing the type restrictions and letting the compiler figure it out worked for me in a project that uses this. ~I think that's all that needs to change here, but I'm not 100% sure~

edit:
I saw on travis it complained about 

```
In src/channel.cr:231:9

 231 | def write(slice : Slice(UInt8))

           ^----

Warning: this method overrides IO#write(slice : Bytes) which has an explicit return type of Int64.

Please add an explicit return type (Int64 or a subtype of it) to this method as well.

The above warning will become an error in a future Crystal version.

In src/channel.cr:105:7

 105 | def write(slice : Slice(UInt8))

           ^----

Warning: this method overrides IO#write(slice : Bytes) which has an explicit return type of Int64.

Please add an explicit return type (Int64 or a subtype of it) to this method as well.

The above warning will become an error in a future Crystal version.

In src/sftp/file.cr:29:9

 29 | def write(slice : Slice(UInt8))

          ^----

Warning: this method overrides IO#write(slice : Bytes) which has an explicit return type of Int64.

Please add an explicit return type (Int64 or a subtype of it) to this method as well.

The above warning will become an error in a future Crystal version.

A total of 3 warnings were found.
```

so I redid this with making them Int64 instead of nothing. 


