### PR TITLE
Add support for channel_direct_streamlocal

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -2,6 +2,9 @@ name: ssh2
 version: 1.5.3
 crystal: ">= 0.36.1"
 
+libraries:
+  libssh2: ">= 1.11.0"
+
 development_dependencies:
   ameba:
     github: veelenga/ameba

--- a/src/lib_ssh2.cr
+++ b/src/lib_ssh2.cr
@@ -279,6 +279,7 @@ Void*) -> Void
                                              message_len : UInt32) : Channel
   fun channel_direct_tcpip = libssh2_channel_direct_tcpip_ex(session : Session, host : UInt8*, port : Int32,
                                                              shost : UInt8*, sport : Int32) : Channel
+  fun channel_direct_streamlocal = libssh2_channel_direct_streamlocal_ex(session : Session, socket_path : UInt8*, shost : UInt8*, sport : Int32) : Channel
   fun channel_close = libssh2_channel_close(ch : Channel) : Int32
   fun channel_eof = libssh2_channel_eof(ch : Channel) : Int32
   fun channel_process_startup = libssh2_channel_process_startup(ch : Channel, request : UInt8*, request_len : UInt32,

--- a/src/session.cr
+++ b/src/session.cr
@@ -385,6 +385,21 @@ class SSH2::Session
     end
   end
 
+  # Tunnel TCP/IP connect through the SSH session to direct UNIX socket.
+  def direct_streamlocal(path, host, port)
+    handle = nonblock_handle { LibSSH2.channel_direct_streamlocal(self, path, host, port) }
+    Channel.new self, handle
+  end
+
+  def direct_streamlocal(path, host, port)
+    channel = direct_streamlocal(path, host, port)
+    begin
+      yield channel
+    ensure
+      channel.close
+    end
+  end
+
   # Send a file to the remote host via SCP.
   def scp_send(path, mode, size, mtime, atime)
     handle = nonblock_handle { LibSSH2.scp_send(self, path, mode.to_i32, size.to_u64,


### PR DESCRIPTION
`libssh2` has now [support for tunnelling to a UNIX socket](https://github.com/libssh2/libssh2/blob/e9c7d3afa0bdf3a004846324213df938b94343b2/src/channel.c#L463), but only in its latest version `1.11.0`.

I'm not sure how this would behave on previous version of the library.