### PR TITLE
Include `pkg_config` value in `Link` annotation

### DIFF
--- a/src/lib_ssh2.cr
+++ b/src/lib_ssh2.cr
@@ -1,4 +1,4 @@
-@[Link("ssh2")]
+@[Link("ssh2", pkg_config: "libssh2")]
 lib LibSSH2
   alias Session = Void*
 


### PR DESCRIPTION
When using https://github.com/crystal-lang/crystal/releases/download/1.14.1/crystal-1.14.1-1-darwin-universal.tar.gz, such as via https://github.com/crystal-lang/install-crystal, the linker is unable to find `ssh2` without this change given it's not bundled with the archive. 

E.g.

```cr
require "ssh2"

SSH2::Session.open("my_server") { }
```

```sh
$ ./crystal-1.14.1-1/bin/crystal --version
Crystal 1.14.1 [db6128a37] (2025-01-08)

LLVM: 15.0.7
Default target: aarch64-apple-macosx11.0
```

```sh
$ ./crystal-1.14.1-1/bin/crystal build test.cr
ld: library 'ssh2' not found
clang: error: linker command failed with exit code 1 (use -v to see invocation)
Error: execution of command failed with exit status 1: clang "${@}" -o /Users/george/Downloads/test  -rdynamic -L/Users/george/Downloads/crystal-1.14.1-1/embedded/lib -lssh2 -lz `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libssl || printf %s '-lssl -lcrypto'` `command -v pkg-config > /dev/null && pkg-config --libs --silence-errors libcrypto || printf %s '-lcrypto'` -L/opt/homebrew/Cellar/bdw-gc/8.2.8/lib -lgc -L/opt/homebrew/Cellar/libevent/2.1.12_1/lib -levent -liconv
```

However after adding this, it build successfully.