### PR TITLE
default to outbound when libssh2 returns EAGAIN with bd=0

### DIFF
--- a/src/session.cr
+++ b/src/session.cr
@@ -41,14 +41,22 @@ class SSH2::Session
 
   alias Directions = LibSSH2::BlockDirections
 
+  # libssh2 can return EAGAIN with bd == 0 (send_existing in transport.c).
+  # waiting on neither side spins the fiber until read_timeout. assume outbound.
+  # https://github.com/libssh2/libssh2/pull/1945
+  private def resolved_directions
+    dir = block_directions
+    dir.none? ? Directions::Outbound : dir
+  end
+
   {% if compare_versions(Crystal::VERSION, "1.14.1") <= 0 %}
-    private def waitsocket(direction : Directions = block_directions)
+    private def waitsocket(direction : Directions = resolved_directions)
       @socket.wait_readable if direction.inbound?
       @socket.wait_writable if direction.outbound?
     end
   {% else %}
     # this works for crystal 1.16 and above
-    private def waitsocket(direction : Directions = block_directions)
+    private def waitsocket(direction : Directions = resolved_directions)
       event_loop = Crystal::EventLoop.current
       event_loop.wait_readable(@socket) if direction.inbound?
       event_loop.wait_writable(@socket) if direction.outbound?


### PR DESCRIPTION
Hi folks :wave: 

In `perform_nonblock` / `nonblock_handle`, when `libssh2` returns `EAGAIN` we wait on whatever side `block_directions` reports. The problem is that `libssh2` can return `EAGAIN` with `block_directions == 
0`.
We then wait on neither side, the call returns instantly, the loop retries, `libssh2` returns `EAGAIN` again, and the fiber spins until `read_timeout` finally fires.

This patch resolves the direction once in a helper, and falls back to Outbound when `libssh2` hands us a zero value.

See also [PR 1945](https://github.com/libssh2/libssh2/pull/1945).

**PS:** I'm looking for a new adventure in case anybody is looking to hire someone or in case someone would like to work with a (Ruby/Rails/Crystal) dev and I'm also open to move to a PO/PM role.